### PR TITLE
Fix a status of the run at JobMonitor

### DIFF
--- a/dirac/public/javascripts/jobs/JobMonitor.js
+++ b/dirac/public/javascripts/jobs/JobMonitor.js
@@ -73,6 +73,7 @@ function initSidebar(){
   var minSelect = createMenu('minorstat','Minor status'); // Initializing Minor Status Menu
   var prodSelect = createMenu('prod','JobGroup'); // Initializing JobGroup Menu
   var id = genericID('id','JobID'); // Initialize field for JobIDs
+  var runid = genericID('runNumber','RunID','','','None'); // Initialize field for JobIDs
   var dateSelect = dateTimeWidget(); // Initializing date dialog
   var select = selectPanel(); // Initializing container for selection objects
   // Insert object to container BEFORE buttons:
@@ -83,7 +84,8 @@ function initSidebar(){
   select.insert(4,ownerSelect);
   select.insert(5,prodSelect);
   select.insert(6,id);
-  select.insert(7,dateSelect);
+  select.insert(7,runid);
+  select.insert(8,dateSelect);
   var sortGlobal = sortGlobalPanel(); // Initializing the global sort panel
 //  var stat = statPanel('Current Statistics','current','statGrid');
 /*

--- a/dirac/public/javascripts/jobs/Lib.js
+++ b/dirac/public/javascripts/jobs/Lib.js
@@ -913,7 +913,7 @@ function genericID(name,fieldLabel,altRegex,altRegexText,hide){
     selectOnFocus:true,
     value:value
   });
-  if(hide){
+  if(hide == true){
     textField.on({
       'render':function(){
         if(textField.value !== ''){


### PR DESCRIPTION
BUGFIX: http://savannah.cern.ch/bugs/?82807
The job monitor window correctly shows the first 25 jobs associated to that run, but when one then tries to go on to the next 25 jobs, or expand the view to more than 25 items per page, ALL the jobs of the PRODUCTION become selected.
