### PR TITLE
Allow users with "JobMonitor" permission to see all jobs in web interface

### DIFF
--- a/dirac/controllers/jobs/JobMonitor.py
+++ b/dirac/controllers/jobs/JobMonitor.py
@@ -362,8 +362,8 @@ class JobmonitorController(BaseController):
       if request.params.has_key("types") and len(request.params["types"]) > 0:
         if str(request.params["types"]) != "All":
           req["JobType"] = str(request.params["types"]).split(separator)
-      if not "JobAdministrator" in groupProperty
-         and not "JobSharing" in groupProperty
+      if not "JobAdministrator" in groupProperty \
+         and not "JobSharing" in groupProperty \
          and not "JobMonitor" in groupProperty:
         if not request.params.has_key("globalStat"):
           req["Owner"] = str(user)

--- a/dirac/controllers/jobs/JobMonitor.py
+++ b/dirac/controllers/jobs/JobMonitor.py
@@ -362,7 +362,9 @@ class JobmonitorController(BaseController):
       if request.params.has_key("types") and len(request.params["types"]) > 0:
         if str(request.params["types"]) != "All":
           req["JobType"] = str(request.params["types"]).split(separator)
-      if not "JobAdministrator" in groupProperty and not "JobSharing" in groupProperty:
+      if not "JobAdministrator" in groupProperty
+         and not "JobSharing" in groupProperty
+         and not "JobMonitor" in groupProperty:
         if not request.params.has_key("globalStat"):
           req["Owner"] = str(user)
       else:


### PR DESCRIPTION
The backend allows the user to access all these data via the API, but the web interface insists on filtering it by user as it doesn't recognise the permission.
