### PR TITLE
Fixed issue with location and name of gMonitor and InstallTools

### DIFF
--- a/dirac/config/environment.py
+++ b/dirac/config/environment.py
@@ -57,7 +57,8 @@ def initDIRAC( rootPath, enableDebug = False ):
     gLogger.initialize( "Web", "/Website" )
     gLogger.setLevel( "VERBOSE" )
 
-    from DIRAC import gMonitor, gConfig, rootPath as droot
+    from DIRAC import gConfig, rootPath as droot
+    from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
     from DIRAC.Core.Utilities import CFG
     from DIRAC.ConfigurationSystem.Client.Helpers import getCSExtensions
     gMonitor.setComponentType( gMonitor.COMPONENT_WEB )
@@ -152,10 +153,10 @@ def getRelease( rootPath ):
 
 def portalVersion( rootPath ):
 
-  from DIRAC.Core.Utilities import InstallTools
+  from DIRAC.FrameworkSystem.Client.ComponentInstaller import gComponentInstaller
   from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import getCSExtensions
 
-  result = InstallTools.getInfo( getCSExtensions() )
+  result = gComponentInstaller.getInfo( getCSExtensions() )
 
   if not result[ "OK" ]:
     return getRelease( rootPath )

--- a/dirac/lib/webBase.py
+++ b/dirac/lib/webBase.py
@@ -7,9 +7,10 @@ import dirac.lib.yuiWidgets as yuiWidgets
 from dirac.lib.webconfig import gWebConfig
 import dirac.lib.helpers as helpers
 from pylons import request
-from DIRAC import gMonitor, gLogger
+from DIRAC import gLogger
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import getCSExtensions
-from DIRAC.Core.Utilities import InstallTools
+from DIRAC.FrameworkSystem.Client.ComponentInstaller import gComponentInstaller
 
 
 def currentPath():
@@ -143,7 +144,7 @@ def getSetups():
   return "[%s]" % ",".join( availableSetups )
 
 def getVersion():
-  result = InstallTools.getInfo( getCSExtensions() )
+  result = gComponentInstaller.getInfo( getCSExtensions() )
   if not result[ "OK" ]:
     return ""
 


### PR DESCRIPTION
Hi,

During DIRAC v6r15 installation some issues have caused an internal server error in the Web module.

I have introduced required fixes but they make the code incompatible with older DIRAC versions (pre v6p15?), so an increase of the version number is probably required too.
